### PR TITLE
Fix: Space.removeShape trashing arbiter list.

### DIFF
--- a/lib/cpSpace.js
+++ b/lib/cpSpace.js
@@ -250,7 +250,7 @@ Space.prototype.filterArbiters = function(body, filter)
 			// Call separate when removing shapes.
 			if(filter && arb.state !== 'cached') arb.callSeparate(this);
 			
-			if(filter && arb.state !== 'ignore') arb.unthread();
+			arb.unthread();
 
 			deleteObjFromList(this.arbiters, arb);
 			//this.pooledArbiters.push(arb);


### PR DESCRIPTION
When a collision is ignored (returning false on the begin callback), the related arbiter doesn't make into the arbiter list of the body. But when the shape is removed, the space tries to unthread this ignored arbiter off the body arbiter list, trashing it.
I'm not sure if this is a good solution because I could'nt really grasp all the code. But this seems to work for me.
