### PR TITLE
fix bug: missing call

### DIFF
--- a/lib/cpSpatialIndex.js
+++ b/lib/cpSpatialIndex.js
@@ -98,7 +98,7 @@ SpatialIndex.prototype.collideStatic = function(staticIndex, func)
 		var query = staticIndex.query;
 
 		this.each(function(obj) {
-			query(obj, new BB(obj.bb_l, obj.bb_b, obj.bb_r, obj.bb_t), func);
+			query.call(obj, new BB(obj.bb_l, obj.bb_b, obj.bb_r, obj.bb_t), func);
 		});
 	}
 };


### PR DESCRIPTION
when calling space.step , error happened with intersectsBB typeerror (not a funciton), because "this" is referring global context ...